### PR TITLE
Fix typo in constructor comment

### DIFF
--- a/GroupBoxControl.cpp
+++ b/GroupBoxControl.cpp
@@ -15,7 +15,7 @@
 #include <memory>
 #include <windows.h>
 
-GroupBoxControl::GroupBoxControl(QWidget *parent) //konstrukor
+GroupBoxControl::GroupBoxControl(QWidget *parent) // konstruktor
     : QWidget(parent)
     , keyTimer(std::make_unique<QTimer>(this))
     , countdownTimer(std::make_unique<QTimer>(this))


### PR DESCRIPTION
## Summary
- correct typo in GroupBoxControl's constructor comment

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f58f0705c8333b8b16ff5cdc5c776