### PR TITLE
Add Qt unit test framework

### DIFF
--- a/AutoKeyPresser.cpp
+++ b/AutoKeyPresser.cpp
@@ -3,10 +3,34 @@
 
 #include <QDebug>
 #include <unordered_map>
-#include <windows.h>
+#ifdef _WIN32
+#  include <windows.h>
+#else
+#  define VK_LEFT 0x25
+#  define VK_UP 0x26
+#  define VK_RIGHT 0x27
+#  define VK_DOWN 0x28
+#  define VK_SPACE 0x20
+#  define VK_RETURN 0x0D
+#  define VK_ESCAPE 0x1B
+#  define VK_F1 0x70
+#  define VK_F2 0x71
+#  define VK_F3 0x72
+#  define VK_F4 0x73
+#  define VK_F5 0x74
+#  define VK_F6 0x75
+#  define VK_F7 0x76
+#  define VK_F8 0x77
+#  define VK_F9 0x78
+#  define VK_F10 0x79
+#  define VK_F11 0x7A
+#  define VK_F12 0x7B
+#endif
 
 AutoKeyPresser::AutoKeyPresser() {}
 AutoKeyPresser::~AutoKeyPresser() {}
+
+#ifdef _WIN32
 
 void AutoKeyPresser::WindowHandleFromPoint(HWND &handle, HWND &parentHandle)
 {
@@ -65,3 +89,22 @@ void AutoKeyPresser::SentKey(const HWND handle, const QString &key)
         qDebug() << "Nieznany klawisz:" << key;
     }
 }
+#else
+void AutoKeyPresser::WindowHandleFromPoint(HWND &handle, HWND &parentHandle)
+{
+    Q_UNUSED(handle);
+    Q_UNUSED(parentHandle);
+}
+
+QString AutoKeyPresser::GetWindowTextFromHandle(const HWND hwnd) const
+{
+    Q_UNUSED(hwnd);
+    return QString();
+}
+
+void AutoKeyPresser::SentKey(const HWND handle, const QString &key)
+{
+    Q_UNUSED(handle);
+    Q_UNUSED(key);
+}
+#endif

--- a/AutoKeyPresser.h
+++ b/AutoKeyPresser.h
@@ -2,7 +2,11 @@
 #pragma once
 
 #include <QString>
-#include <Windows.h>
+#ifdef _WIN32
+#  include <Windows.h>
+#else
+using HWND = void *;
+#endif
 
 class AutoKeyPresser
 {

--- a/GlobalKeyListener.cpp
+++ b/GlobalKeyListener.cpp
@@ -2,6 +2,7 @@
 #include <QDebug>
 #include <QKeySequence>
 #include <QMetaObject>
+#ifdef _WIN32
 
 // Uchwyt do hooka systemowego (Windows Hook)
 HHOOK GlobalKeyListener::hook = nullptr;
@@ -197,3 +198,12 @@ QString GlobalKeyListener::opisVK(int vk)
     // Jeśli klawisz jest znany — zwracamy jego nazwę; jeśli nie, to np. "VK_27"
     return mapa.value(vk, QString("VK_%1").arg(vk));
 }
+#else
+HHOOK GlobalKeyListener::hook = nullptr;
+GlobalKeyListener *GlobalKeyListener::instance = nullptr;
+
+GlobalKeyListener::GlobalKeyListener(QObject *parent) : QObject(parent) {}
+GlobalKeyListener::~GlobalKeyListener() {}
+void GlobalKeyListener::start() {}
+QString GlobalKeyListener::opisVK(int) { return QString(); }
+#endif

--- a/GlobalKeyListener.h
+++ b/GlobalKeyListener.h
@@ -2,7 +2,14 @@
 #define GLOBALKEYLISTENER_H
 
 #include <QObject>
-#include <Windows.h>
+#ifdef _WIN32
+#  include <Windows.h>
+#else
+using HHOOK = void *;
+using WPARAM = unsigned long;
+using LPARAM = long;
+using LRESULT = long;
+#endif
 
 class GlobalKeyListener : public QObject
 {

--- a/GroupBoxControl.cpp
+++ b/GroupBoxControl.cpp
@@ -13,7 +13,11 @@
 #include <QSizePolicy>
 #include <QTimer>
 #include <memory>
-#include <windows.h>
+#ifdef _WIN32
+#  include <windows.h>
+#else
+inline void Beep(int, int) {}
+#endif
 
 GroupBoxControl::GroupBoxControl(QWidget *parent) // konstruktor
     : QWidget(parent)

--- a/OknoBot.cpp
+++ b/OknoBot.cpp
@@ -6,6 +6,25 @@
 #include "ui_OknoBot.h"
 
 #include "GroupBoxControl.h"
+#ifndef _WIN32
+#  define VK_SPACE 0x20
+#  define VK_RETURN 0x0D
+#  define VK_F1 0x70
+#  define VK_F2 0x71
+#  define VK_F3 0x72
+#  define VK_F4 0x73
+#  define VK_F5 0x74
+#  define VK_F6 0x75
+#  define VK_F7 0x76
+#  define VK_F8 0x77
+#  define VK_F9 0x78
+#  define VK_F10 0x79
+#  define VK_F11 0x7A
+#  define VK_F12 0x7B
+#  define VK_NUMPAD1 0x61
+#  define VK_NUMPAD2 0x62
+#  define VK_NUMPAD0 0x60
+#endif
 
 OknoBot::OknoBot(QWidget *parent)
     : QWidget(parent)

--- a/QtBot.pro
+++ b/QtBot.pro
@@ -33,3 +33,7 @@ FORMS += \
 qnx: target.path = /tmp/$${TARGET}/bin
 else: unix:!android: target.path = /opt/$${TARGET}/bin
 !isEmpty(target.path): INSTALLS += target
+
+check.target = check
+check.commands = cd tests && qmake && $(MAKE) check
+QMAKE_EXTRA_TARGETS += check

--- a/tests/test_oknobot.cpp
+++ b/tests/test_oknobot.cpp
@@ -1,0 +1,25 @@
+#include <QtTest/QtTest>
+#include "../OknoBot.h"
+
+class TestOknoBot : public QObject {
+    Q_OBJECT
+private slots:
+    void test_getAllData();
+};
+
+void TestOknoBot::test_getAllData()
+{
+    int argc = 0;
+    char *argv[] = {nullptr};
+    QApplication app(argc, argv);
+
+    OknoBot bot;
+    QMetaObject::invokeMethod(&bot, "dodajRzad", Qt::DirectConnection);
+    QMetaObject::invokeMethod(&bot, "dodajRzad", Qt::DirectConnection);
+
+    QString expected = "Nowy GroupBox;;;0s;0ms;\nNowy GroupBox;;;0s;0ms;\n";
+    QCOMPARE(bot.getAllDataFromGroupBox(), expected);
+}
+
+QTEST_MAIN(TestOknoBot)
+#include "test_oknobot.moc"

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -1,0 +1,11 @@
+QT += core gui widgets testlib
+CONFIG += c++17 testcase
+
+SOURCES += test_oknobot.cpp \
+           ../OknoBot.cpp \
+           ../GroupBoxControl.cpp \
+           ../AutoKeyPresser.cpp \
+           ../GlobalKeyListener.cpp
+
+FORMS += ../OknoBot.ui
+INCLUDEPATH += ..


### PR DESCRIPTION
## Summary
- make AutoKeyPresser and other sources build without Windows
- define a `check` target in `QtBot.pro`
- add a QtTest project under `tests/`
- test OknoBot aggregation logic

## Testing
- `qmake && make check` *(fails: `qmake` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f59defeec83338deddf7cbc3d23f1